### PR TITLE
Force defining the function

### DIFF
--- a/ftdetect/node.js.vim
+++ b/ftdetect/node.js.vim
@@ -6,7 +6,7 @@
 " Install via pathogen by cloning/adding submodule in ~/.vim/bundle or
 " by dropping this script in ~/vim/ftdetect
 
-function DetectNode()
+function! DetectNode()
   if !did_filetype()
     if getline(1) =~ '^#.*\<node\>'
       setfiletype javascript


### PR DESCRIPTION
We use this plugin in [Janus](https://github.com/carlhuda/janus), the problem is some oses ship it as a package and this leads to errors since the function is defined somewhere in the runtime already.

Please see https://github.com/carlhuda/janus/issues/336 for more information.
