### PR TITLE
Force verymagic regex match mode

### DIFF
--- a/ftdetect/node.js.vim
+++ b/ftdetect/node.js.vim
@@ -8,7 +8,7 @@
 
 function! DetectNode()
   if !did_filetype()
-    if getline(1) =~ '^#.*(\<node\>|\<iojs\>)'
+    if getline(1) =~ '\v^#.*(<node>|<iojs>)'
       setfiletype javascript
     endif
   endif


### PR DESCRIPTION
Force the comparison regex to operate in `verymagic` mode, despite any user settings.
Fix #2 
